### PR TITLE
Facilities Dropdown Disable Functionality

### DIFF
--- a/scripts/Facilities.js
+++ b/scripts/Facilities.js
@@ -1,4 +1,5 @@
 import { setFacility } from "./TransientState.js";
+import { state } from "./TransientState.js"
 
 export const generateFacilitiesHTML = async () => {
     try {
@@ -8,13 +9,14 @@ export const generateFacilitiesHTML = async () => {
 
         let html = `
         <div id="facilities-container">Facilities
-            <select id="facility-select"><option value="0">Choose A Facility:</option>
+            <select id="facility-select" disabled>
+                <option value="0">Choose A Facility:</option>
                 ${data.map((facility) => {
-            if (facility.active) {
-                return `<option value="${facility.id}">${facility.name}</option>`;
-            } else {
-                return '';
-            }
+                    if (facility.active) {
+                        return `<option value="${facility.id}">${facility.name}</option>`;
+                    } else {
+                        return '';
+                    }
         }).join('')}
             </select>
         </div>`;
@@ -25,6 +27,17 @@ export const generateFacilitiesHTML = async () => {
         return `<p>Error fetching facilities data: ${error.message}</p>`;
     }
 };
+
+const enableFacilityDropdown = () => {
+    const facilitySelect = document.getElementById("facility-select")
+    if (state.governorId !==0) {
+        facilitySelect.disabled = false
+    } else {
+        facilitySelect.disabled = true
+    }
+}
+
+document.addEventListener("stateChanged", enableFacilityDropdown)
 
 const attachFacilitiesListeners = (Event) => {
     if (Event.target.id === 'facility-select') {


### PR DESCRIPTION
# Description

As per the project requirements, we must disable the "facilities" dropdown menu until the user has selected a governor from the governor dropdown menu. I am only committing changes to the Facilities.js module.

- [x] New feature (non-breaking change which adds functionality)

# How Should I Test This?

1. Fetch new code.
2. Run new code in the browser.
3. Click on the facility dropdown menu button; make sure it does not allow the user to select a facility.
4. Select a governor in the governor dropdown menu.
5. Now, check if the facility dropdown menu works (it should).

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors
